### PR TITLE
Change spectator update interval from 2000 to 100

### DIFF
--- a/src/main/kotlin/rat/poison/scripts/SpectatorList.kt
+++ b/src/main/kotlin/rat/poison/scripts/SpectatorList.kt
@@ -17,7 +17,7 @@ import rat.poison.utils.every
 import rat.poison.utils.extensions.readIndex
 import rat.poison.utils.notInGame
 
-internal fun spectatorList() = every(2000) {
+internal fun spectatorList() = every(100) {
     if (!curSettings["SPECTATOR_LIST"].strToBool() || notInGame || !curSettings["MENU"].strToBool()) {
         return@every
     }


### PR DESCRIPTION
Change spectator update interval from 2000 to 100 (ms?) 

It seemed very slow for me, so just went in and changed update interval. Hopefully it will be more responsive. 