### PR TITLE
Parameter 'j' is never used, could be renamed to _

### DIFF
--- a/src/main/kotlin/rat/poison/scripts/Ranks.kt
+++ b/src/main/kotlin/rat/poison/scripts/Ranks.kt
@@ -98,7 +98,7 @@ internal fun ranks() = every(1000) { //Rebuild every second
 
         //b r u h
         ctPlayers.forEachIndexed { _, ent->
-            ent.forEachIndexed { j, str->
+            ent.forEachIndexed { _, str->
                 ranksListTable.add(VisLabel(str))
             }
             ranksListTable.row()
@@ -106,7 +106,7 @@ internal fun ranks() = every(1000) { //Rebuild every second
         ranksListTable.add(VisLabel()).row()
 
         tPlayers.forEachIndexed { _, ent->
-            ent.forEachIndexed { j, str->
+            ent.forEachIndexed { _, str->
                 ranksListTable.add(VisLabel(str))
             }
             ranksListTable.row()


### PR DESCRIPTION
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Task :compileKotlin
w: C:\EasyRP\EasyRP\RatPoison-master\src\main\kotlin\rat\poison\scripts\Ranks.kt: (101, 34): Parameter 'j' is never used, could be renamed to _
w: C:\EasyRP\EasyRP\RatPoison-master\src\main\kotlin\rat\poison\scripts\Ranks.kt: (109, 34): Parameter 'j' is never used, could be renamed to _